### PR TITLE
fix: 新密钥不传给cosApi

### DIFF
--- a/ios/Classes/CosPlugin.m
+++ b/ios/Classes/CosPlugin.m
@@ -443,9 +443,10 @@ QCloudThreadSafeMutableDictionary *QCloudCOSTaskCache() {
     getPresignedURLRequest.object = cosPath;
     getPresignedURLRequest.HTTPMethod = @"GET";
 
-    if(signValidTime){
-        getPresignedURLRequest.expires = [NSDate dateWithTimeIntervalSinceNow:[signValidTime intValue]];
-    }
+    // 2024-08-08 腾讯突然 expires not found error了
+    // if(signValidTime){
+    //     getPresignedURLRequest.expires = [NSDate dateWithTimeIntervalSinceNow:[signValidTime intValue]];
+    // }
     
     if(signHost){
         // 获取预签名函数，默认签入Header Host；您也可以选择不签入Header Host，但可能导致请求失败或安全漏洞

--- a/ios/Classes/CosPlugin.m
+++ b/ios/Classes/CosPlugin.m
@@ -443,10 +443,9 @@ QCloudThreadSafeMutableDictionary *QCloudCOSTaskCache() {
     getPresignedURLRequest.object = cosPath;
     getPresignedURLRequest.HTTPMethod = @"GET";
 
-    // 2024-08-08 腾讯突然 expires not found error了
-    // if(signValidTime){
-    //     getPresignedURLRequest.expires = [NSDate dateWithTimeIntervalSinceNow:[signValidTime intValue]];
-    // }
+    if(signValidTime){
+        getPresignedURLRequest.expires = [NSDate dateWithTimeIntervalSinceNow:[signValidTime intValue]];
+    }
     
     if(signHost){
         // 获取预签名函数，默认签入Header Host；您也可以选择不签入Header Host，但可能导致请求失败或安全漏洞

--- a/ios/tencentcloud_cos_sdk_plugin.podspec
+++ b/ios/tencentcloud_cos_sdk_plugin.podspec
@@ -17,7 +17,7 @@ Tencent COS Flutter Plugin SDK.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'QCloudCOSXML','>= 6.4.0'
+  s.dependency 'QCloudCOSXML','= 6.4.0'
   s.platform = :ios, '9.0'
   s.static_framework = true
 

--- a/lib/cos.dart
+++ b/lib/cos.dart
@@ -97,7 +97,8 @@ class Cos {
   /// 包括SessionCredential或ScopeLimitCredential
   Future<void> forceInvalidationCredential() async {
     flutterCosApi.forceInvalidationScopeCredentials();
-    return await _cosApi.forceInvalidationCredential();
+    await _cosApi.forceInvalidationCredential();
+    _initialized = false;
   }
 
   Future<void> setCloseBeacon(bool isCloseBeacon) async {


### PR DESCRIPTION
https://github.com/TencentCloud/cos-sdk-flutter-plugin/issues/13

强制清老临时密钥和用新的临时密钥,新密钥不传给cosApi

```dart
  /// 强制让本地保存临时秘钥失效
  /// 包括SessionCredential或ScopeLimitCredential
  Future<void> forceInvalidationCredential() async {
    flutterCosApi.forceInvalidationScopeCredentials();
    await _cosApi.forceInvalidationCredential();
    _initialized = false; // 加了这一步不知道合不合适
  }
```